### PR TITLE
Add ClawdTalk - Voice AI for agents

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,7 @@ This repository contains **complete AI applications** organized into 5 main cate
 Simple, single-purpose AI agents perfect for learning and quick implementations:
 - <img src="https://www.ai21.com/wp-content/uploads/2024/11/ai21-logo.svg" alt="AI21 logo" width="40" height="10"> **[AI21 Studio Chat](./starter-agents/ai21-studio-chat/)** - Jurassic model integration
 - <img src="https://cdn.simpleicons.org/elevenlabs" alt="ElevenLabs logo" width="20" height="20"> **[Voice-Enabled Chatbot](./starter-agents/elevenlabs-voice-assistant/)** - Voice-enabled chatbot using ElevenLabs
+- <img src="https://cdn.simpleicons.org/telnyx" alt="Telnyx logo" width="20" height="20"> **[ClawdTalk](./starter-agents/clawdtalk/)** - Voice interface for AI agents built on Telnyx
 - <img src="https://zorgle.co.uk/wp-content/uploads/2024/11/Claude-ai-logo.png" alt="Anthropic Claude logo" width="20" height="20"> **[Claude 4 Conversation Agent](./starter-agents/claude-3-conversation-agent/)** - Conversation agent using Claude models
 - <img src="https://cdn.simpleicons.org/googlegemini" alt="Gemini logo" width="20" height="20"> **[Google PaLM Chat](./starter-agents/google-palm-chat/)** - Conversation agent using Google PaLM models
 - <img src="https://cdn.simpleicons.org/meta" alt="Meta logo" width="20" height="20"> **[Local Llama Chat](./starter-agents/local-llama-chat/)** - Conversation agent using Local Llama models

--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ This repository contains **complete AI applications** organized into 5 main cate
 Simple, single-purpose AI agents perfect for learning and quick implementations:
 - <img src="https://www.ai21.com/wp-content/uploads/2024/11/ai21-logo.svg" alt="AI21 logo" width="40" height="10"> **[AI21 Studio Chat](./starter-agents/ai21-studio-chat/)** - Jurassic model integration
 - <img src="https://cdn.simpleicons.org/elevenlabs" alt="ElevenLabs logo" width="20" height="20"> **[Voice-Enabled Chatbot](./starter-agents/elevenlabs-voice-assistant/)** - Voice-enabled chatbot using ElevenLabs
-- <img src="https://cdn.simpleicons.org/telnyx" alt="Telnyx logo" width="20" height="20"> **[ClawdTalk](./starter-agents/clawdtalk/)** - Voice interface for AI agents built on Telnyx
+- <img src="https://img.shields.io/badge/Telnyx-00E3AA?style=flat&logo=telnyx" alt="Telnyx logo" width="50" height="20"> **[ClawdTalk](./starter-agents/clawdtalk/)** - Voice interface for AI agents built on Telnyx
 - <img src="https://zorgle.co.uk/wp-content/uploads/2024/11/Claude-ai-logo.png" alt="Anthropic Claude logo" width="20" height="20"> **[Claude 4 Conversation Agent](./starter-agents/claude-3-conversation-agent/)** - Conversation agent using Claude models
 - <img src="https://cdn.simpleicons.org/googlegemini" alt="Gemini logo" width="20" height="20"> **[Google PaLM Chat](./starter-agents/google-palm-chat/)** - Conversation agent using Google PaLM models
 - <img src="https://cdn.simpleicons.org/meta" alt="Meta logo" width="20" height="20"> **[Local Llama Chat](./starter-agents/local-llama-chat/)** - Conversation agent using Local Llama models

--- a/starter-agents/clawdtalk/README.md
+++ b/starter-agents/clawdtalk/README.md
@@ -1,0 +1,22 @@
+# ClawdTalk - Voice AI for Agents
+
+Voice calling capability for AI agents powered by [Telnyx](https://telnyx.com).
+
+## Features
+- Inbound/outbound phone calls for AI agents
+- Speech-to-text and text-to-speech via Telnyx
+- WebSocket-based real-time audio streaming
+- Tool calling during live conversations
+
+## Quick Start
+
+```bash
+npm install clawdtalk-client
+```
+
+See the [ClawdTalk documentation](https://clawdtalk.com) for setup instructions.
+
+## Requirements
+- Node.js 18+
+- Telnyx account with API key
+- Phone number provisioned on Telnyx


### PR DESCRIPTION
This PR adds ClawdTalk to the Starter Agents section. ClawdTalk is a voice interface for AI agents built on Telnyx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ClawdTalk as a new voice-interface starter agent built on Telnyx.
  * Added user-facing documentation covering features (inbound/outbound calling, speech, real‑time streaming, tool calling), quick start, requirements, installation, and external references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->