### PR TITLE
Add Agent Reach — internet access for AI agents

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,10 +65,10 @@ Track our progress and upcoming releases to see what we're building next!
 
 ## 🔗 Reference Resources
 
-- [Agent Reach](https://github.com/Panniantong/Agent-Reach) - Give your AI agents internet access in 30 seconds. Scaffolding tool supporting 9+ platforms (Twitter, YouTube, Reddit, Bilibili, Xiaohongshu, GitHub, RSS, Web, Exa). Works with Claude Code, OpenClaw, Cursor, Windsurf.
 
 This collection was inspired by and references patterns from:
 - [Awesome LLM Apps](https://github.com/Shubhamsaboo/awesome-llm-apps)
+- [Agent Reach](https://github.com/Panniantong/Agent-Reach) - Give your AI agents internet access in 30 seconds. Scaffolding tool supporting 9+ platforms (Twitter, YouTube, Reddit, Bilibili, Xiaohongshu, GitHub, RSS, Web, Exa). Works with Claude Code, OpenClaw, Cursor, Windsurf.
 
 ## 📄 License
 

--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,8 @@ Track our progress and upcoming releases to see what we're building next!
 
 ## 🔗 Reference Resources
 
+- [Agent Reach](https://github.com/Panniantong/Agent-Reach) - Give your AI agents internet access in 30 seconds. Scaffolding tool supporting 9+ platforms (Twitter, YouTube, Reddit, Bilibili, Xiaohongshu, GitHub, RSS, Web, Exa). Works with Claude Code, OpenClaw, Cursor, Windsurf.
+
 This collection was inspired by and references patterns from:
 - [Awesome LLM Apps](https://github.com/Shubhamsaboo/awesome-llm-apps)
 


### PR DESCRIPTION
## Agent Reach

[Agent Reach](https://github.com/Panniantong/Agent-Reach) gives any AI coding agent internet capabilities in 30 seconds.

GitHub: https://github.com/Panniantong/Agent-Reach


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Agent Reach to the Reference Resources section of the README with a brief description of its capabilities and the platforms it supports.
  * Introduced the new reference entry as a visible bullet in the resources list.
  * No functional or behavioral changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->