### PR TITLE
Add clawr.ing — phone calling for AI agents

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,7 @@ This repository contains **complete AI applications** organized into 5 main cate
 Simple, single-purpose AI agents perfect for learning and quick implementations:
 - <img src="https://www.ai21.com/wp-content/uploads/2024/11/ai21-logo.svg" alt="AI21 logo" width="40" height="10"> **[AI21 Studio Chat](./starter-agents/ai21-studio-chat/)** - Jurassic model integration
 - <img src="https://cdn.simpleicons.org/elevenlabs" alt="ElevenLabs logo" width="20" height="20"> **[Voice-Enabled Chatbot](./starter-agents/elevenlabs-voice-assistant/)** - Voice-enabled chatbot using ElevenLabs
+- 📞 **[clawr.ing](https://clawr.ing)** - Phone calling service for AI agents. Outbound calls across 100+ countries with 70+ voices. Built with Bun, Hono, Telnyx, AssemblyAI, and Inworld.
 - <img src="https://zorgle.co.uk/wp-content/uploads/2024/11/Claude-ai-logo.png" alt="Anthropic Claude logo" width="20" height="20"> **[Claude 4 Conversation Agent](./starter-agents/claude-3-conversation-agent/)** - Conversation agent using Claude models
 - <img src="https://cdn.simpleicons.org/googlegemini" alt="Gemini logo" width="20" height="20"> **[Google PaLM Chat](./starter-agents/google-palm-chat/)** - Conversation agent using Google PaLM models
 - <img src="https://cdn.simpleicons.org/meta" alt="Meta logo" width="20" height="20"> **[Local Llama Chat](./starter-agents/local-llama-chat/)** - Conversation agent using Local Llama models


### PR DESCRIPTION
## Summary

- Adds [clawr.ing](https://clawr.ing) to the Starter Agents section — a phone calling service that gives AI agents the ability to make real outbound phone calls.
- Supports 100+ countries, 70+ voices. Built with Bun, Hono, Telnyx, AssemblyAI, and Inworld.
- Used for alerts, morning briefings, reminders, and other voice-based agent workflows.

Placed next to the Voice-Enabled Chatbot entry since they share the voice/telephony domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Starter Agent entry: clawr.ing, featuring AI-powered phone calling capabilities supporting outbound calls across 100+ countries with 70+ voice options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->