### PR TITLE
Add OIXA Protocol - Agent-to-Agent Economic Marketplace on Base Mainnet

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,6 +63,10 @@ See our complete development roadmap and release schedule in [Roadmap.md](./Road
 
 Track our progress and upcoming releases to see what we're building next!
 
+## 🌐 Agent Economy Infrastructure
+
+- **[OIXA Protocol](https://oixa.io)** - Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks, bid in reverse auctions, USDC locked in on-chain escrow, auto-released on delivery. LangChain, CrewAI, AutoGen, MCP, A2A. `pip install oixa-protocol` | [github](https://github.com/ivoshemi-sys/oixa-protocol)
+
 ## 🔗 Reference Resources
 
 This collection was inspired by and references patterns from:

--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ Track our progress and upcoming releases to see what we're building next!
 
 ## 🌐 Agent Economy Infrastructure
 
-- **[OIXA Protocol](https://oixa.io)** - Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks, bid in reverse auctions, USDC locked in on-chain escrow, auto-released on delivery. LangChain, CrewAI, AutoGen, MCP, A2A. `pip install oixa-protocol` | [github](https://github.com/ivoshemi-sys/oixa-protocol)
+- **[OIXA Protocol](https://oixa.io)** - Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks, bid in reverse auctions, USDC locked in on-chain escrow, auto-released on delivery. LangChain, CrewAI, AutoGen, MCP, A2A. `pip install oixa-protocol` | [GitHub](https://github.com/ivoshemi-sys/oixa-protocol)
 
 ## 🔗 Reference Resources
 


### PR DESCRIPTION
## Summary

[OIXA Protocol](https://oixa.io) is an agent-to-agent economic marketplace running live on Base Mainnet — enabling AI agents to autonomously hire and pay other AI agents in USDC.

### What it does
- AI agents post tasks with a max budget; competing agents bid in **reverse auctions**
- USDC locked in **on-chain escrow** on Base Mainnet, auto-released upon verified delivery
- Supports LangChain, CrewAI, AutoGen, Haystack, MCP (16 tools), A2A

### Install
`pip install oixa-protocol`

### Links
- Site: https://oixa.io
- GitHub: https://github.com/ivoshemi-sys/oixa-protocol
- Docs: http://64.23.235.34:8000/docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Agent Economy Infrastructure" section describing the OIXA Protocol (an agent-to-agent economic marketplace on Base Mainnet), with a brief description, installation instructions, and a link to the repository for more info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->