### PR TITLE
Add Uni-CLI

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,8 @@ Simple, single-purpose AI agents perfect for learning and quick implementations:
 - <img src="https://zorgle.co.uk/wp-content/uploads/2024/11/Claude-ai-logo.png" alt="Anthropic Claude logo" width="20" height="20"> **[Claude Code Reviewer](./starter-agents/claude-code-reviewer/)** - Code reviewer using Claude Sonnet 4
 - <img src="https://registry.npmmirror.com/@lobehub/icons-static-png/latest/files/dark/together-color.png" alt="Together AI logo" width="20" height="20"> **[Streaming Response Chat Bot](./starter-agents/together-ai-chat/)** - Real-time chatbot with Together AI streaming responses
 
+- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** - Universal CLI for AI agents with 756 commands across 167 sites (web, desktop, Electron). Self-repairing YAML adapters, auto-JSON output, ~80 tokens per call
+
 ### 🧠 [Advanced Agents](./advanced-agents/)
 Sophisticated AI agents with complex reasoning and multi-step workflows:
 - <img src="https://cdn.simpleicons.org/googlegemini" alt="Gemini logo" width="20" height="20"> **[Brand Video Monitor](./advanced-agents/brand-video-monitor/)** - Brand video monitoring and analysis

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ Simple, single-purpose AI agents perfect for learning and quick implementations:
 - <img src="https://zorgle.co.uk/wp-content/uploads/2024/11/Claude-ai-logo.png" alt="Anthropic Claude logo" width="20" height="20"> **[Claude Code Reviewer](./starter-agents/claude-code-reviewer/)** - Code reviewer using Claude Sonnet 4
 - <img src="https://registry.npmmirror.com/@lobehub/icons-static-png/latest/files/dark/together-color.png" alt="Together AI logo" width="20" height="20"> **[Streaming Response Chat Bot](./starter-agents/together-ai-chat/)** - Real-time chatbot with Together AI streaming responses
 
-- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** - Universal CLI for AI agents with 756 commands across 167 sites (web, desktop, Electron). Self-repairing YAML adapters, auto-JSON output, ~80 tokens per call
+- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** - Universal CLI for AI agents with 1,458 commands across 238 sites (web, desktop, Electron). Self-repairing YAML adapters with structured error envelopes; per-call token budget published in [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)
 
 ### 🧠 [Advanced Agents](./advanced-agents/)
 Sophisticated AI agents with complex reasoning and multi-step workflows:

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ Simple, single-purpose AI agents perfect for learning and quick implementations:
 - <img src="https://zorgle.co.uk/wp-content/uploads/2024/11/Claude-ai-logo.png" alt="Anthropic Claude logo" width="20" height="20"> **[Claude Code Reviewer](./starter-agents/claude-code-reviewer/)** - Code reviewer using Claude Sonnet 4
 - <img src="https://registry.npmmirror.com/@lobehub/icons-static-png/latest/files/dark/together-color.png" alt="Together AI logo" width="20" height="20"> **[Streaming Response Chat Bot](./starter-agents/together-ai-chat/)** - Real-time chatbot with Together AI streaming responses
 
-- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** - Universal CLI for AI agents with 1,458 commands across 238 sites (web, desktop, Electron). Self-repairing YAML adapters with structured error envelopes; per-call token budget published in [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)
+- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** - Universal CLI for AI agents — exposes web, desktop, and Electron apps as deterministic commands. Self-repairing YAML adapters with structured error envelopes; live catalog size and per-call token budget tracked in the repo's [README](https://github.com/olo-dot-io/Uni-CLI#readme) and [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md)
 
 ### 🧠 [Advanced Agents](./advanced-agents/)
 Sophisticated AI agents with complex reasoning and multi-step workflows:


### PR DESCRIPTION
[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) is a universal CLI for AI agents — 756 commands across 167 sites (web, desktop, Electron). Features self-repairing 20-line YAML adapters, auto-JSON output, and ~80 tokens per call. TypeScript, Apache-2.0.

Added to the **Starter Agents** section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Uni-CLI to featured Starter Agents as a universal CLI for AI agents, highlighting deterministic command behavior across web, desktop, and Electron, self-repairing YAML adapter support, and structured error envelopes.
  * Included links to live catalog size and per-call token budget information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->